### PR TITLE
Add additional `pqrs::hid::usage::consumer` keys

### DIFF
--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -340,6 +340,7 @@ constexpr value_t scan_next_track(0x00b5);
 constexpr value_t scan_previous_track(0x00b6);
 constexpr value_t eject(0x00b8);
 constexpr value_t play_or_pause(0x00cd);
+constexpr value_t stop(0x00b7);
 constexpr value_t voice_command(0x00cf);
 constexpr value_t mute(0x00e2);
 constexpr value_t volume_increment(0x00e9);

--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -435,6 +435,7 @@ constexpr value_t ac_bookmarks(0x022a);
 constexpr value_t ac_zoom_out(0x22d);
 constexpr value_t ac_zoom_in(0x22e);
 constexpr value_t ac_pan(0x0238); // Horizontal mouse wheel
+constexpr value_t ac_search(0x0221);
 
 } // namespace consumer
 

--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -346,6 +346,7 @@ constexpr value_t mute(0x00e2);
 constexpr value_t volume_increment(0x00e9);
 constexpr value_t volume_decrement(0x00ea);
 constexpr value_t bass_boost(0x00e5);
+constexpr value_t bass_decrement(0x0153);
 
 // application launch buttons
 

--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -346,6 +346,7 @@ constexpr value_t mute(0x00e2);
 constexpr value_t volume_increment(0x00e9);
 constexpr value_t volume_decrement(0x00ea);
 constexpr value_t bass_boost(0x00e5);
+constexpr value_t bass_increment(0x0152);
 constexpr value_t bass_decrement(0x0153);
 constexpr value_t loudness(0x00e7);
 

--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -347,6 +347,7 @@ constexpr value_t volume_increment(0x00e9);
 constexpr value_t volume_decrement(0x00ea);
 constexpr value_t bass_boost(0x00e5);
 constexpr value_t bass_decrement(0x0153);
+constexpr value_t loudness(0x00e7);
 
 // application launch buttons
 

--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -345,6 +345,7 @@ constexpr value_t voice_command(0x00cf);
 constexpr value_t mute(0x00e2);
 constexpr value_t volume_increment(0x00e9);
 constexpr value_t volume_decrement(0x00ea);
+constexpr value_t bass_boost(0x00e5);
 
 // application launch buttons
 


### PR DESCRIPTION
These will be used in a PR for Karabiner-Elements to support customizing an old Compaq keyboard