### PR TITLE
Add consumer keycodes for Mission Control and Launchpad

### DIFF
--- a/include/pqrs/hid/usage.hpp
+++ b/include/pqrs/hid/usage.hpp
@@ -663,6 +663,11 @@ constexpr value_t ac_zoom_out(0x22d);
 constexpr value_t ac_zoom_in(0x22e);
 constexpr value_t ac_pan(0x0238); // Horizontal mouse wheel
 constexpr value_t ac_keyboard_layout_select(0x029d);
+constexpr value_t ac_desktop_show_all_windows(0x29f);
+// ac_soft_key_left and ac_desktop_show_all_applications had conflicting codes
+// fixed in HUTRR97, but some keyboards still use the old value so support it
+constexpr value_t ac_soft_key_left(0x2a0);
+constexpr value_t ac_desktop_show_all_applications(0x2a2);
 
 } // namespace consumer
 


### PR DESCRIPTION
Keyboards can use `usage::consumer::ac_desktop_show_all_windows` (usage page `0x000c`, usage `0x029f`) and `usage::consumer::ac_desktop_show_all_applications` (usage page `0x000c`, usage `0x02a2`) for Mission Control and Launchpad, respectively, without needing to use Apple's private-use keycodes. Recognize these keycodes in cpp-hid so that they can be used in Karabiner-Elements.

`usage::consumer::ac_soft_key_left` (usage page `0x000c`, usage `0x02a0`) is used by some keyboards instead of `ac_desktop_show_all_applications` due to a mistake in the HID specification where the same keycode (`0x02a0`) was assigned to two different usages. Some keyboards still make use of the older "incorrect" keycode, so support this usage as well. macOS recognizes both keycodes for Launchpad.

Initial support for resolving pqrs-org/Karabiner-Elements#3310.